### PR TITLE
Information-map 페이지 컴포넌트 추가

### DIFF
--- a/src/pages/InformationMap.tsx
+++ b/src/pages/InformationMap.tsx
@@ -1,13 +1,22 @@
 import styled from 'styled-components';
+import HeaderMain from '@/components/HeaderMain';
+import HeaderSearch from '@/components/HeaderSearch';
 
 const InformationMap = () => {
-  return <Title>청약지도</Title>;
+  return (
+    <Container>
+      <HeaderMain />
+      <HeaderSearch />
+    </Container>
+  );
 };
 
-const Title = styled.h1`
-  color: var(--g10);
-  font-size: 24px;
-  font-weight: bold;
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--n30);
 `;
 
 export default InformationMap;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#46-feature/information-map-page-component-add

## 📝 작업 내용

Information-map 페이지 컴포넌트 추가

## 📸 스크린샷

<img width="321" alt="스크린샷 2024-11-19 오후 6 31 25" src="https://github.com/user-attachments/assets/1d92eb31-91a4-4f59-9347-8faeabc58b7a">
